### PR TITLE
cuda: decouple helper from fixed sm_120 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,41 @@ option(HBFSIM_ENABLE_CUDA "Build CUDA instrumentation and runtime components" ON
 option(HBFSIM_ENABLE_MQSIM "Build the MQSim-backed host service" ON)
 option(HBFSIM_ENABLE_LLM_TESTS "Enable llama.cpp and vLLM integration tests" OFF)
 
+if(HBFSIM_ENABLE_CUDA)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(
+            CMAKE_CUDA_ARCHITECTURES 120 CACHE STRING
+            "Single CUDA architecture supported by the embedded HBFSim helper"
+        )
+    endif()
+    if(NOT "${CMAKE_CUDA_ARCHITECTURES}" MATCHES "^[1-9][0-9]*$")
+        message(
+            FATAL_ERROR
+            "HBFSim requires one numeric baseline CUDA architecture because "
+            "the device helper PTX is embedded into instrumented modules; "
+            "found '${CMAKE_CUDA_ARCHITECTURES}'"
+        )
+    endif()
+    set(HBFSIM_CUDA_ARCHITECTURE "${CMAKE_CUDA_ARCHITECTURES}")
+    if(HBFSIM_CUDA_ARCHITECTURE LESS 70)
+        message(
+            FATAL_ERROR
+            "HBFSim requires compute capability 7.0 or newer for "
+            "__match_any_sync, __nanosleep, and acquire/release system atomics; "
+            "found sm_${HBFSIM_CUDA_ARCHITECTURE}"
+        )
+    endif()
+    set(HBFSIM_CUDA_PTX_TARGET "sm_${HBFSIM_CUDA_ARCHITECTURE}")
+    if(NOT HBFSIM_CUDA_ARCHITECTURE STREQUAL "120")
+        message(
+            WARNING
+            "sm_${HBFSIM_CUDA_ARCHITECTURE} is a non-reference HBFSim target. "
+            "A successful build does not establish live host/GPU control "
+            "protocol validation on that platform."
+        )
+    endif()
+endif()
+
 include(CTest)
 include(cmake/Dependencies.cmake)
 find_package(OpenSSL REQUIRED COMPONENTS Crypto)
@@ -249,20 +284,6 @@ if(BUILD_TESTING)
     find_program(HBFSIM_PYTHON3_EXECUTABLE python3 REQUIRED)
 endif()
 
-if(BUILD_TESTING AND HBFSIM_ENABLE_CUDA)
-    add_test(
-        NAME ptxpass_plugin
-        COMMAND
-            "${HBFSIM_PYTHON3_EXECUTABLE}"
-            "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/test_ptxpass_plugin.py"
-            "$<TARGET_FILE:ptxpass_hbf_plugin>"
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/ptxpass_hbf/plugin.cpp"
-    )
-    set_tests_properties(
-        ptxpass_plugin PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    )
-endif()
-
 if(BUILD_TESTING)
     add_test(
         NAME llama_cpp_adapter
@@ -399,7 +420,7 @@ if(TARGET PkgConfig::LIBBPF AND HBFSIM_CLANG_EXECUTABLE)
         COMMAND
             "${CMAKE_CUDA_COMPILER}" --ptx
             "${CMAKE_CURRENT_SOURCE_DIR}/adapters/llama_cpp/hbfsim_llama_probe.cu"
-            -std=c++17 "--gpu-architecture=compute_${CMAKE_CUDA_ARCHITECTURES}"
+            -std=c++17 "--gpu-architecture=compute_${HBFSIM_CUDA_ARCHITECTURE}"
             -o "${HBFSIM_LLAMA_PROBE_PTX}"
         DEPENDS
             "${CMAKE_CURRENT_SOURCE_DIR}/adapters/llama_cpp/hbfsim_llama_probe.cu"
@@ -415,7 +436,7 @@ if(TARGET PkgConfig::LIBBPF AND HBFSIM_CLANG_EXECUTABLE)
     set_target_properties(
         hbfsim_llama_probe_module PROPERTIES
         OUTPUT_NAME hbfsim_llama_probe
-        CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
+        CUDA_ARCHITECTURES "${HBFSIM_CUDA_ARCHITECTURE}"
         POSITION_INDEPENDENT_CODE ON
     )
     set(HBFSIM_VLLM_PROBE "${CMAKE_BINARY_DIR}/vllm_fused_moe_probe.bpf.o")
@@ -480,7 +501,7 @@ if(CUDAToolkit_FOUND)
                     "${CMAKE_BINARY_DIR}/generated"
             COMMAND
                 "${CUDAToolkit_NVCC_EXECUTABLE}" --ptx --std=c++20
-                --gpu-architecture=compute_120
+                "--gpu-architecture=compute_${HBFSIM_CUDA_ARCHITECTURE}"
                 --relocatable-device-code=true --keep-device-functions
                 "--compiler-bindir=${HBFSIM_NVCC_HOST_COMPILER}"
                 "-I${CMAKE_CURRENT_SOURCE_DIR}/src/cuda_runtime/device"
@@ -504,10 +525,16 @@ if(CUDAToolkit_FOUND)
             hbfsim_core PRIVATE "${CMAKE_BINARY_DIR}/generated"
         )
         target_compile_definitions(
-            hbfsim_core PRIVATE HBFSIM_HAVE_DEVICE_HELPER_PTX=1
+            hbfsim_core
+            PRIVATE
+                HBFSIM_HAVE_DEVICE_HELPER_PTX=1
+                "HBFSIM_DEVICE_PTX_ARCHITECTURE=${HBFSIM_CUDA_ARCHITECTURE}"
         )
         target_compile_definitions(
-            ptx_transform_test PRIVATE HBFSIM_TEST_DEVICE_HELPER_PTX=1
+            ptx_transform_test
+            PRIVATE
+                HBFSIM_TEST_DEVICE_HELPER_PTX=1
+                "HBFSIM_TEST_DEVICE_PTX_ARCHITECTURE=${HBFSIM_CUDA_ARCHITECTURE}"
         )
     endif()
 
@@ -632,6 +659,7 @@ if(CUDAToolkit_FOUND)
                         "$<TARGET_FILE:ptxpass_hbf_plugin>"
                         "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/ptx/supported.ptx"
                         "${CUDAToolkit_VERSION}"
+                        "${HBFSIM_CUDA_PTX_TARGET}"
             )
         endif()
         add_test(
@@ -659,7 +687,8 @@ if(HBFSIM_ENABLE_CUDA)
     )
     set_target_properties(
         unsupported_kernel PROPERTIES
-        CUDA_ARCHITECTURES "120-real;120-virtual"
+        CUDA_ARCHITECTURES
+            "${HBFSIM_CUDA_ARCHITECTURE}-real;${HBFSIM_CUDA_ARCHITECTURE}-virtual"
         CUDA_RUNTIME_LIBRARY Shared
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/gpu"
     )
@@ -709,7 +738,8 @@ if(HBFSIM_ENABLE_CUDA)
     )
     set_target_properties(
         capacity_runtime_live_test PROPERTIES
-        CUDA_ARCHITECTURES "75-real;75-virtual"
+        CUDA_ARCHITECTURES
+            "${HBFSIM_CUDA_ARCHITECTURE}-real;${HBFSIM_CUDA_ARCHITECTURE}-virtual"
         CUDA_RUNTIME_LIBRARY Shared
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/gpu"
     )
@@ -728,12 +758,27 @@ if(HBFSIM_ENABLE_CUDA)
             REQUIRED
         )
         add_test(
+            NAME ptxpass_plugin
+            COMMAND
+                "${HBFSIM_PYTHON3_EXECUTABLE}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/test_ptxpass_plugin.py"
+                "$<TARGET_FILE:ptxpass_hbf_plugin>"
+                "${CMAKE_CURRENT_SOURCE_DIR}/src/ptxpass_hbf/plugin.cpp"
+                "${HBFSIM_PTXAS_EXECUTABLE}"
+                "${HBFSIM_CUDA_PTX_TARGET}"
+        )
+        set_tests_properties(
+            ptxpass_plugin PROPERTIES
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        add_test(
             NAME unsupported_kernel_ptx
             COMMAND
                 "${HBFSIM_PYTHON3_EXECUTABLE}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/test_cuda_ptx.py"
                 "$<TARGET_FILE:unsupported_kernel>"
                 "${CUDAToolkit_BIN_DIR}/cuobjdump"
+                "${HBFSIM_CUDA_PTX_TARGET}"
         )
         add_test(
             NAME device_helper_ptx
@@ -743,6 +788,7 @@ if(HBFSIM_ENABLE_CUDA)
                 "$<TARGET_FILE:ptxpass_hbf_plugin>"
                 "${HBFSIM_DEVICE_PTX}"
                 "${HBFSIM_PTXAS_EXECUTABLE}"
+                "${HBFSIM_CUDA_PTX_TARGET}"
         )
         set_tests_properties(
             device_helper_ptx PROPERTIES

--- a/README.md
+++ b/README.md
@@ -300,6 +300,35 @@ Build options:
 | `HBFSIM_ENABLE_MQSIM` | `ON` | Build the online MQSim backend and media benchmark |
 | `HBFSIM_ENABLE_LLM_TESTS` | `OFF` | Enable environment-dependent llama.cpp and vLLM integration tests |
 
+### Selecting a CUDA architecture
+
+The CUDA device helper does not use Blackwell-only instructions. A build can
+therefore select one numeric baseline architecture of compute capability 7.0
+or newer through `CMAKE_CUDA_ARCHITECTURES`; `120` remains the default and the
+reference target. A single architecture is required because HBFSim embeds the
+helper PTX into each instrumented module. Compiling and assembling another
+target is not proof that the live host/GPU control protocol is portable to that
+platform: CUDA does not guarantee that GPU atomics to mapped page-locked host
+memory are atomic from the host's point of view. See
+[`docs/cuda-architecture-compatibility.md`](docs/cuda-architecture-compatibility.md)
+for the feature audit, support levels, and validation requirements.
+
+CUDA Toolkit can be kept in a user directory without installing a Linux driver
+or changing the shell environment. For example:
+
+```bash
+env \
+  CUDAToolkit_ROOT="$HOME/opt/cuda-12.8" \
+  CUDACXX="$HOME/opt/cuda-12.8/bin/nvcc" \
+  PATH="$HOME/opt/cuda-12.8/bin:$PATH" \
+  cmake -S . -B build-sm89 -G Ninja \
+    -DHBFSIM_ENABLE_CUDA=ON \
+    -DHBFSIM_ENABLE_MQSIM=ON \
+    -DCMAKE_CUDA_ARCHITECTURES=89 \
+    -DCUDAToolkit_ROOT="$HOME/opt/cuda-12.8" \
+    -DCMAKE_CUDA_COMPILER="$HOME/opt/cuda-12.8/bin/nvcc"
+```
+
 ## Run the MQSim media benchmark
 
 The current benchmark submits deterministic sequential requests through
@@ -385,11 +414,12 @@ Run its integration check with:
 
 ```bash
 python3 tests/integration/run_ptxpass_json.py \
-  build/src/ptxpass_hbf/ptxpass_hbf
+  build/src/ptxpass_hbf/ptxpass_hbf sm_120 "$(command -v ptxas)"
 ```
 
-When CUDA 12.8 is installed, the check assembles the rewritten PTX for
-`sm_120` with `ptxas`. The initial pass recognizes selected scalar/vector,
+When CUDA 12.8 is installed, the check assembles rewritten PTX for the
+single architecture selected at configure time with `ptxas`. The initial pass
+recognizes selected scalar/vector,
 predicated, offset, and cache-qualified global loads and stores. Atomics,
 generic-space operations, texture/surface operations, malformed addresses, and
 inline SASS remain outside the supported HBF path. The runtime coverage gate
@@ -428,7 +458,8 @@ cmake -S . -B build-gpu-static -G Ninja \
 cmake --build build-gpu-static -j
 ctest --test-dir build-gpu-static --output-on-failure
 python3 tests/integration/run_ptxpass_json.py \
-  build-gpu-static/src/ptxpass_hbf/ptxpass_hbf
+  build-gpu-static/src/ptxpass_hbf/ptxpass_hbf sm_120 \
+  /usr/local/cuda-12.8/bin/ptxas
 ```
 
 The design contract and implementation plan are in:

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(
 )
 set_target_properties(
     hbf_microbench PROPERTIES
-    CUDA_ARCHITECTURES "120-virtual"
+    CUDA_ARCHITECTURES "${HBFSIM_CUDA_ARCHITECTURE}-virtual"
     CUDA_RUNTIME_LIBRARY Shared
     ENABLE_EXPORTS ON
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/benchmarks/cuda"
@@ -17,7 +17,7 @@ add_custom_command(
     OUTPUT "${HBFSIM_MICROBENCH_PTX}"
     COMMAND
         "${CMAKE_CUDA_COMPILER}" --ptx --std=c++20
-        --gpu-architecture=compute_120
+        "--gpu-architecture=compute_${HBFSIM_CUDA_ARCHITECTURE}"
         "--compiler-bindir=${HBFSIM_NVCC_HOST_COMPILER}"
         "${CMAKE_CURRENT_SOURCE_DIR}/hbf_microbench_kernel.cu"
         -o "${HBFSIM_MICROBENCH_PTX}"
@@ -40,7 +40,7 @@ target_include_directories(
 )
 set_target_properties(
     hbf_vmem_tuning_bench PROPERTIES
-    CUDA_ARCHITECTURES "120-virtual"
+    CUDA_ARCHITECTURES "${HBFSIM_CUDA_ARCHITECTURE}-virtual"
     CUDA_RUNTIME_LIBRARY Shared
     ENABLE_EXPORTS ON
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/benchmarks/cuda"
@@ -53,7 +53,7 @@ add_custom_command(
     OUTPUT "${HBFSIM_VMEM_TUNING_PTX}"
     COMMAND
         "${CMAKE_CUDA_COMPILER}" --ptx --std=c++20
-        --gpu-architecture=compute_120
+        "--gpu-architecture=compute_${HBFSIM_CUDA_ARCHITECTURE}"
         "--compiler-bindir=${HBFSIM_NVCC_HOST_COMPILER}"
         -DHBFSIM_VMEM_KERNEL_ONLY=1
         "${CMAKE_CURRENT_SOURCE_DIR}/hbf_vmem_tuning_bench.cu"

--- a/docs/cuda-architecture-compatibility.md
+++ b/docs/cuda-architecture-compatibility.md
@@ -1,0 +1,92 @@
+# CUDA architecture compatibility
+
+HBFSim's device resolver is a baseline CUDA implementation, not a Blackwell
+instruction implementation. The reference proofs remain native Linux on
+`sm_120`, but the source-level instruction requirements begin at compute
+capability 7.0. This document defines what an alternate architecture build does
+and does not establish.
+
+## Required CUDA features
+
+| HBFSim use | Source | Minimum or runtime requirement |
+|---|---|---|
+| Warp coalescing by range and logical page | `__match_any_sync`, `__shfl_sync`, `__activemask` in `hbf_device.cu` | `__match_any_sync` requires CC 7.0 |
+| Bounded device polling | `__nanosleep` in `hbf_device.cu` | CC 7.0 |
+| Request/completion ordering | `cuda::atomic_ref<..., thread_scope_system>`; generated PTX uses acquire/release system-scope atomics | PTX memory semantics require `sm_70`; system-wide atomics are not available on Tegra before CC 7.2 |
+| GPU timestamping | `%globaltimer` in the resolver and llama.cpp probe | `sm_30`, but NVIDIA documents the register as target-specific; each platform needs timing calibration |
+| Shared control mapping | `cudaHostRegisterMapped` and `cudaHostGetDevicePointer` | Host registration and mapped-host-memory support on the runtime platform |
+| Capacity address space and HBM-role cache | `cuMemAddressReserve`, `cuMemCreate`, `cuMemMap`, and `cuMemSetAccess` | `CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED`; the Driver API calls fail closed when unavailable |
+
+The resolver does **not** use Tensor Cores, thread-block clusters, distributed
+shared memory, TMA, `mbarrier`, `cp.async`, `multimem`, or Blackwell `tcgen05`
+instructions. Those architecture-specific features are therefore not a reason
+to restrict the helper to `sm_120`.
+
+There is one portability boundary that a compute capability number cannot
+settle. NVIDIA states that atomic functions operating on mapped host memory are
+not atomic from the point of view of the host or other GPUs. HBFSim's control
+protocol performs CPU/GPU acquire/release operations and cross-domain RMWs on
+such a mapping. A successful compile and `ptxas` run therefore proves device
+instruction compatibility, not the full live protocol. Alternate platforms
+must pass the live validation sequence below before their results are treated
+as reference-quality evidence.
+
+## Architecture families covered by CUDA 12.8
+
+| Baseline target | NVIDIA architecture | HBFSim build status |
+|---|---|---|
+| `sm_70`, `sm_72` | Volta | Source-level candidate; CC 7.0 is the helper minimum |
+| `sm_75` | Turing | Source-level candidate |
+| `sm_80`, `sm_86`, `sm_87` | Ampere | Source-level candidate |
+| `sm_89` | Ada | Compile/assembly and local CUDA/VMM tests; full live protocol remains experimental |
+| `sm_90` / `sm_90a` | Hopper | Source-level candidate |
+| `sm_100`, `sm_100a`, `sm_101`, `sm_101a` | Blackwell | Source-level candidate |
+| `sm_120`, `sm_120a` | Blackwell | Reference build and proof target |
+
+CUDA distinguishes baseline targets from architecture-specific `a` targets.
+HBFSim always compiles its embedded helper for the numeric baseline because it
+uses no architecture-specific instructions. The PTX pass may inject that helper
+into a module with the same numeric target and an `a` suffix, but never into a
+different baseline SM target. This preserves PTX module compatibility while
+avoiding an architecture allowlist.
+
+## Configure and validation policy
+
+Select exactly one numeric architecture per build directory:
+
+```bash
+cmake -S . -B build-sm89 -G Ninja \
+  -DHBFSIM_ENABLE_CUDA=ON \
+  -DCMAKE_CUDA_ARCHITECTURES=89
+```
+
+The single-target rule is intentional. `cmake/EmbedDevicePtx.cmake` removes the
+helper's module directives and inserts its functions into workload PTX, so the
+helper and workload must share one baseline target. Separate build directories
+are required to validate multiple architectures. CMake rejects non-numeric,
+multi-target, and pre-Volta selections; NVCC remains the authority on whether
+the installed Toolkit implements a particular numeric target.
+
+An alternate GPU should be promoted from build-compatible to live-validated
+only after all of the following pass on that GPU and operating environment:
+
+1. Compile the helper and representative benchmark kernels for the selected
+   `compute_XX`, then assemble rewritten PTX with `ptxas -arch=sm_XX`.
+2. Run the CPU, fake-CUDA, PTX-pass, launch-gate, and coverage tests.
+3. Query host registration and CUDA VMM support and run
+   `capacity_runtime_live_test`.
+4. Stress the mapped control queue bidirectionally, including CPU/GPU RMW,
+   timeout, shutdown, and failure transitions.
+5. Run timing-only and capacity microbenchmarks with fail-closed coverage, then
+   recalibrate the latency profile for that GPU.
+6. Validate the relevant llama.cpp or vLLM adapter separately; adapter proof is
+   not implied by the core helper build.
+
+## NVIDIA references
+
+- [CUDA C++ Programming Guide: compute capabilities](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/compute-capabilities.html)
+- [CUDA 12.8 Programming Guide: `__match_any_sync` and `__nanosleep`](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-c-programming-guide/index.html)
+- [PTX ISA 8.7: memory model, atomics, targets, and `%globaltimer`](https://docs.nvidia.com/cuda/archive/12.8.0/parallel-thread-execution/index.html)
+- [CUDA Programming Guide: mapped host memory atomicity](https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/understanding-memory.html)
+- [CUDA 12.8 Driver API device attributes](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-driver-api/group__CUDA__TYPES.html)
+- [CUDA 12.8 NVCC target architecture support](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-compiler-driver-nvcc/index.html)

--- a/src/ptxpass_hbf/transform.cpp
+++ b/src/ptxpass_hbf/transform.cpp
@@ -10,9 +10,42 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace hbfsim::ptx {
 namespace {
+
+#define HBFSIM_STRINGIFY_DETAIL(value) #value
+#define HBFSIM_STRINGIFY(value) HBFSIM_STRINGIFY_DETAIL(value)
+
+#if !defined(HBFSIM_DEVICE_PTX_ARCHITECTURE)
+#define HBFSIM_DEVICE_PTX_ARCHITECTURE 120
+#endif
+
+constexpr std::string_view kDevicePtxArchitecture =
+    HBFSIM_STRINGIFY(HBFSIM_DEVICE_PTX_ARCHITECTURE);
+constexpr unsigned kDevicePtxArchitectureNumber =
+    HBFSIM_DEVICE_PTX_ARCHITECTURE;
+
+std::string device_ptx_target()
+{
+    return "sm_" + std::string{kDevicePtxArchitecture};
+}
+
+bool has_compatible_device_target(const std::string& ptx)
+{
+    static const std::regex target(
+        R"(^\s*\.target\s+sm_([0-9]+)(a?)(?:\s|,|$))",
+        std::regex::multiline);
+    std::smatch match;
+    if (!std::regex_search(ptx, match, target) ||
+        match[1].str() != kDevicePtxArchitecture) {
+        return false;
+    }
+    const auto suffix = match[2].str();
+    return suffix.empty() ||
+           (suffix == "a" && kDevicePtxArchitectureNumber >= 90);
+}
 
 bool unsupported_memory_instruction(const std::string& line,
                                     std::string& opcode)
@@ -69,11 +102,11 @@ void append_device_helper(std::string& ptx, bool trusted_existing_helper)
         throw std::runtime_error(
             "PTX module collides with the reserved HBFSim device ABI");
     }
-    static const std::regex target(
-        R"(^\s*\.target\s+sm_120a?(?:\s|,|$))", std::regex::multiline);
-    if (!std::regex_search(ptx, target)) {
+    const auto expected_target = device_ptx_target();
+    if (!has_compatible_device_target(ptx)) {
         throw std::runtime_error(
-            "HBFSim device helper requires a .target sm_120 or sm_120a PTX module");
+            "HBFSim device helper built for " + expected_target +
+            " cannot instrument a PTX module with a different baseline target");
     }
 #if defined(HBFSIM_HAVE_DEVICE_HELPER_PTX)
     const auto address_size = ptx.find(".address_size");

--- a/tests/cpu/ptx_transform_test.cpp
+++ b/tests/cpu/ptx_transform_test.cpp
@@ -7,6 +7,13 @@
 #include <sstream>
 #include <string>
 
+#define HBFSIM_STRINGIFY_DETAIL(value) #value
+#define HBFSIM_STRINGIFY(value) HBFSIM_STRINGIFY_DETAIL(value)
+
+#if !defined(HBFSIM_TEST_DEVICE_PTX_ARCHITECTURE)
+#define HBFSIM_TEST_DEVICE_PTX_ARCHITECTURE 120
+#endif
+
 #define CHECK(condition)                                                       \
     do {                                                                       \
         if (!(condition)) {                                                    \
@@ -16,11 +23,27 @@
 
 namespace {
 
+std::string configured_ptx(std::string ptx)
+{
+    const std::string default_target = ".target sm_120";
+    const std::string configured_target =
+        ".target sm_" +
+        std::string{HBFSIM_STRINGIFY(HBFSIM_TEST_DEVICE_PTX_ARCHITECTURE)};
+    if (const auto position = ptx.find(default_target);
+        position != std::string::npos) {
+        ptx.replace(position, default_target.size(), configured_target);
+    }
+    return ptx;
+}
+
 std::string read_fixture(const std::string& name)
 {
     std::ifstream input("tests/fixtures/ptx/" + name);
     assert(input);
-    return {std::istreambuf_iterator<char>(input), {}};
+    return configured_ptx(std::string{
+        std::istreambuf_iterator<char>{input},
+        std::istreambuf_iterator<char>{},
+    });
 }
 
 }  // namespace
@@ -64,7 +87,7 @@ int main()
     assert(!hbfsim::ptx::parse_memory_op("ld.u32 %r1, [%rd2];"));
     assert(!hbfsim::ptx::parse_memory_op("ld.global.u32 %r1, [%r2+%r3];"));
 
-    const std::string spoofed_helper = R"ptx(.version 8.7
+    const std::string spoofed_helper = configured_ptx(R"ptx(.version 8.7
 .target sm_120
 .address_size 64
 .visible .const .align 4 .u32 __hbfsim_device_helper_marker = 0x48424632;
@@ -85,7 +108,7 @@ int main()
     ld.global.u32 %r1, [%rd1];
     ret;
 }
-)ptx";
+)ptx");
     bool spoof_rejected = false;
     try {
         (void)hbfsim::ptx::transform_ptx({
@@ -110,7 +133,7 @@ int main()
            std::string::npos);
     assert(result.output_ptx.find("[%hbfsim_addr_") != std::string::npos);
 
-    const std::string production_ptx = R"ptx(.version 8.7
+    const std::string production_ptx = configured_ptx(R"ptx(.version 8.7
 .target sm_120
 .address_size 64
 // __hbfsim_device_helper_marker is not a declaration.
@@ -125,7 +148,7 @@ int main()
     ld.global.u32 %r1, [%rd1];
     ret;
 }
-)ptx";
+)ptx");
     const auto self_contained = hbfsim::ptx::transform_ptx({
         .full_ptx = production_ptx,
         .to_patch_kernel = "production_kernel",

--- a/tests/integration/run_ptxpass_json.py
+++ b/tests/integration/run_ptxpass_json.py
@@ -2,6 +2,7 @@
 
 import json
 import pathlib
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -9,7 +10,14 @@ import tempfile
 
 def main() -> int:
     executable = pathlib.Path(sys.argv[1])
-    fixture = pathlib.Path("tests/fixtures/ptx/supported.ptx").read_text()
+    target = sys.argv[2] if len(sys.argv) > 2 else "sm_120"
+    if not target.removeprefix("sm_").isdigit():
+        raise ValueError(f"expected a baseline sm_XX target, got {target!r}")
+    fixture = pathlib.Path(
+        "tests/fixtures/ptx/supported.ptx"
+    ).read_text().replace(".target sm_120", f".target {target}", 1)
+    if int(target.removeprefix("sm_")) < 75:
+        fixture = fixture.replace(".nc.L2::128B", ".nc")
     request = {
         "input": {
             "full_ptx": fixture,
@@ -31,14 +39,16 @@ def main() -> int:
     assert response["coverage"]["rewritten_instructions"] == 3
     assert "__hbfsim_resolve" in response["output_ptx"]
 
-    ptxas = pathlib.Path("/usr/local/cuda-12.8/bin/ptxas")
-    if ptxas.is_file():
+    ptxas_name = sys.argv[3] if len(sys.argv) > 3 else shutil.which("ptxas")
+    if ptxas_name is not None and pathlib.Path(ptxas_name).is_file():
+        ptxas = pathlib.Path(ptxas_name)
         with tempfile.TemporaryDirectory(prefix="hbfsim-ptx-") as directory:
             ptx_path = pathlib.Path(directory) / "transformed.ptx"
             cubin_path = pathlib.Path(directory) / "transformed.cubin"
             ptx_path.write_text(response["output_ptx"])
             subprocess.run(
-                [str(ptxas), "-arch=sm_120", str(ptx_path), "-o", str(cubin_path)],
+                [str(ptxas), f"-arch={target}", str(ptx_path), "-o",
+                 str(cubin_path)],
                 check=True,
             )
 

--- a/tests/integration/test_cuda_module_association.py
+++ b/tests/integration/test_cuda_module_association.py
@@ -42,20 +42,20 @@ class GateApi(ctypes.Structure):
     ]
 
 
-def canonical_ptx(identity: bytes) -> str:
+def canonical_ptx(identity: bytes, ptx_target: str) -> str:
     values = ", ".join(f"0x{byte:02x}" for byte in identity)
     return (
-        ".version 8.7\n.target sm_120\n.address_size 64\n"
+        f".version 8.7\n.target {ptx_target}\n.address_size 64\n"
         ".visible .const .align 8 .b8 __hbfsim_module_identity[32] = {"
         f"{values}}};\n.visible .entry kernel() {{ ret; }}\n"
     )
 
 
-def manifest(identity: bytes) -> dict:
+def manifest(identity: bytes, ptx_target: str) -> dict:
     return {
         "module_id": "ptx:sha256:" + identity.hex(),
         "kernel": "kernel",
-        "ptx_target": "sm_120",
+        "ptx_target": ptx_target,
         "instrumented": True,
         "cubin_only": False,
         "parameters": [
@@ -71,6 +71,7 @@ def main() -> int:
     plugin = str(pathlib.Path(sys.argv[3]).resolve())
     fixture = str(pathlib.Path(sys.argv[4]).resolve())
     toolkit_version = tuple(int(part) for part in sys.argv[5].split(".")[:2])
+    ptx_target = sys.argv[6]
     if os.environ.get("HBFSIM_FAKE_MODULE_ACTIVE") != "1":
         with tempfile.TemporaryDirectory(prefix="hbfsim-module-association-") as root:
             environment = os.environ.copy()
@@ -92,12 +93,14 @@ def main() -> int:
                 ) if item
             )
             return subprocess.run([sys.executable, __file__, gate, fake,
-                                   plugin, fixture, sys.argv[5]],
+                                   plugin, fixture, sys.argv[5], ptx_target],
                                   env=environment, check=False).returncode
 
     manifest_path = pathlib.Path(os.environ["HBFSIM_PASS_MANIFEST_PATH"])
     initial_identity = bytes([0x42]) + bytes(31)
-    manifest_path.write_text(json.dumps(manifest(initial_identity)) + "\n")
+    manifest_path.write_text(
+        json.dumps(manifest(initial_identity, ptx_target)) + "\n"
+    )
 
     process = ctypes.CDLL(None)
     fake_library = ctypes.CDLL(fake)
@@ -190,7 +193,9 @@ def main() -> int:
     pass_library.process_input.restype = ctypes.c_int
     request = json.dumps({
         "input": {
-            "full_ptx": pathlib.Path(fixture).read_text(),
+            "full_ptx": pathlib.Path(fixture).read_text().replace(
+                ".target sm_120", f".target {ptx_target}", 1
+            ),
             "to_patch_kernel": "kernel",
             "global_ebpf_map_info_symbol": "map_info",
             "ebpf_communication_data_symbol": "constData",
@@ -278,13 +283,13 @@ def main() -> int:
     identity_a = bytes([0xA1]) + bytes(31)
     identity_b = bytes([0xB2]) + bytes(31)
     with manifest_path.open("a") as output:
-        output.write(json.dumps(manifest(identity_b)) + "\n")
+        output.write(json.dumps(manifest(identity_b, ptx_target)) + "\n")
     set_live_identity(identity_b)
     results: dict[str, tuple[int, ctypes.c_void_p]] = {}
     transactions_ready = threading.Barrier(2)
 
     def concurrent_load(name: str, identity: bytes, image: bytes) -> None:
-        require(begin_ptx(canonical_ptx(identity)) != 0,
+        require(begin_ptx(canonical_ptx(identity, ptx_target)) != 0,
                 f"failed to begin concurrent {name} transaction")
         transactions_ready.wait()
         results[name] = load_image(image)

--- a/tests/integration/test_cuda_ptx.py
+++ b/tests/integration/test_cuda_ptx.py
@@ -8,13 +8,14 @@ import sys
 def main() -> int:
     executable = pathlib.Path(sys.argv[1])
     cuobjdump = pathlib.Path(sys.argv[2])
+    expected_target = sys.argv[3]
     completed = subprocess.run(
         [str(cuobjdump), "--dump-ptx", str(executable)],
         text=True,
         capture_output=True,
         check=True,
     )
-    assert ".target sm_120" in completed.stdout
+    assert f".target {expected_target}" in completed.stdout
     assert ".entry unsupported_hbf_kernel" in completed.stdout
     return 0
 

--- a/tests/integration/test_device_helper_ptx.py
+++ b/tests/integration/test_device_helper_ptx.py
@@ -17,6 +17,7 @@ def main() -> int:
     plugin_path = pathlib.Path(sys.argv[1]).resolve()
     helper_path = pathlib.Path(sys.argv[2]).resolve()
     ptxas = pathlib.Path(sys.argv[3]).resolve()
+    configured_target = sys.argv[4]
     helper = helper_path.read_text()
     for symbol in (
         "__hbfsim_control",
@@ -64,7 +65,10 @@ def main() -> int:
         manifest = work_path / "manifest.jsonl"
         import os
         os.environ["HBFSIM_PASS_MANIFEST_PATH"] = str(manifest)
-        for target in ("sm_120", "sm_120a"):
+        targets = [configured_target]
+        if int(configured_target.removeprefix("sm_")) in {90, 100, 101, 120}:
+            targets.append(f"{configured_target}a")
+        for target in targets:
             request = json.dumps({
                 "input": {
                     "full_ptx": ptx_template.replace("{target}", target),
@@ -103,6 +107,28 @@ def main() -> int:
                     f"{assembled.stderr}")
             require(cubin.stat().st_size > 0,
                     f"ptxas produced an empty {target} cubin")
+
+        configured_architecture = int(configured_target.removeprefix("sm_"))
+        mismatched_target = (
+            "sm_75" if configured_architecture == 70 else "sm_70"
+        )
+        for rejected_target in (mismatched_target, f"{configured_target}x"):
+            request = json.dumps({
+                "input": {
+                    "full_ptx": ptx_template.replace(
+                        "{target}", rejected_target
+                    ),
+                    "to_patch_kernel": "timing_kernel",
+                    "global_ebpf_map_info_symbol": "map_info",
+                    "ebpf_communication_data_symbol": "constData",
+                },
+                "ebpf_instructions": [],
+            }).encode()
+            output.value = b""
+            status = plugin.process_input(request, len(output), output)
+            require(status != 0,
+                    f"device-helper pass accepted incompatible target "
+                    f"{rejected_target}")
     return 0
 
 

--- a/tests/integration/test_ptxpass_plugin.py
+++ b/tests/integration/test_ptxpass_plugin.py
@@ -31,6 +31,17 @@ def request_for(ptx: str, kernel: str) -> bytes:
 
 def main() -> int:
     source = pathlib.Path(sys.argv[2]).read_text()
+    ptxas = pathlib.Path(sys.argv[3]).resolve()
+    configured_target = sys.argv[4]
+
+    def configured_fixture(path: str) -> str:
+        ptx = pathlib.Path(path).read_text().replace(
+            ".target sm_120", f".target {configured_target}", 1
+        )
+        if int(configured_target.removeprefix("sm_")) < 75:
+            ptx = ptx.replace(".nc.L2::128B", ".nc")
+        return ptx
+
     for forbidden in ("hbfsim_expect_module_identity",
                       "publish_module_expectation", "dlsym(RTLD_DEFAULT"):
         require(forbidden not in source,
@@ -46,7 +57,7 @@ def main() -> int:
     config = json.loads(config_buffer.value)
     require(config["name"] == "hbf_memory", "unexpected plugin name")
 
-    ptx = pathlib.Path("tests/fixtures/ptx/supported.ptx").read_text()
+    ptx = configured_fixture("tests/fixtures/ptx/supported.ptx")
     request = request_for(ptx, "kernel")
     output = ctypes.create_string_buffer(16 * 1024 * 1024)
     with tempfile.TemporaryDirectory(prefix="hbfsim-pass-") as directory:
@@ -78,7 +89,8 @@ def main() -> int:
                              manifest["module_id"]) is not None,
                 f"manifest lacks SHA-256 module identity: {manifest['module_id']}")
         require(manifest["kernel"] == "kernel", "manifest kernel mismatch")
-        require(manifest["ptx_target"] == "sm_120", "manifest target mismatch")
+        require(manifest["ptx_target"] == configured_target,
+                "manifest target mismatch")
         require(manifest["instrumented"] is True,
                 "supported kernel not marked instrumented")
         require(manifest["cubin_only"] is False,
@@ -143,10 +155,10 @@ def main() -> int:
         ptx_file = pathlib.Path(directory) / "marked.ptx"
         cubin_file = pathlib.Path(directory) / "marked.cubin"
         ptx_file.write_text(response["output_ptx"])
-        ptxas = pathlib.Path("/usr/local/cuda-12.8/bin/ptxas")
         if ptxas.exists():
             assembled = subprocess.run(
-                [str(ptxas), "-arch=sm_120", str(ptx_file), "-o", str(cubin_file)],
+                [str(ptxas), f"-arch={configured_target}", str(ptx_file),
+                 "-o", str(cubin_file)],
                 text=True, capture_output=True
             )
             require(assembled.returncode == 0,
@@ -218,7 +230,8 @@ def main() -> int:
         if ptxas.exists():
             ptx_file.write_text(second_response["output_ptx"])
             assembled = subprocess.run(
-                [str(ptxas), "-arch=sm_120", str(ptx_file), "-o", str(cubin_file)],
+                [str(ptxas), f"-arch={configured_target}", str(ptx_file),
+                 "-o", str(cubin_file)],
                 text=True, capture_output=True,
             )
             require(assembled.returncode == 0,
@@ -241,9 +254,9 @@ def main() -> int:
                 "plugin accepted a mutated trusted module state")
         manifest_path.unlink()
 
-        aggregate_ptx = pathlib.Path(
+        aggregate_ptx = configured_fixture(
             "tests/fixtures/ptx/aggregate_parameter.ptx"
-        ).read_text()
+        )
         aggregate_request = json.dumps(
             {
                 "input": {


### PR DESCRIPTION
## Summary

This PR removes the fixed `sm_120` allowlist from HBFSim's CUDA build while preserving `sm_120` as the default reference target.

- Accept one numeric baseline architecture per build directory, with compute capability 7.0 as the minimum.

- Keep PTX instrumentation fail-closed: the embedded helper and workload module must have the same numeric SM target.

- Parameterize CUDA benchmarks, live tests, PTX fixtures, manifests, `ptxas`, and the manual PTX-pass tool from the configured architecture.

- Add a compatibility audit that separates build compatibility from live protocol validation.

## GPU feature audit

| HBFSim requirement | Minimum or runtime condition |
| --- | --- |
| `__match_any_sync` and `__nanosleep` | Compute capability 7.0 |
| Acquire/release system-scope atomics | PTX memory semantics available from `sm_70` |
| `%globaltimer` | Available before the project minimum; each GPU still requires timing calibration |
| Mapped control memory | Host registration and mapped-host-memory support on the runtime platform |
| Capacity-mode virtual memory | CUDA Driver VMM support |

The helper does not use Tensor Cores, thread-block clusters, TMA, `mbarrier`, `cp.async`, `multimem`, or Blackwell `tcgen05` instructions. These features do not justify restricting the helper to `sm_120`.

## Design constraints

1. Each build directory selects exactly one numeric CUDA architecture. This remains necessary because HBFSim strips the helper PTX module directives and embeds its functions into workload PTX.

2. The PTX pass accepts the configured baseline target and the corresponding architecture-specific `a` target, such as `sm_90` and `sm_90a`.

3. A different SM target or an invalid suffix is rejected. This preserves the existing fail-closed behavior.

4. `sm_120` remains the default and the reference proof target. Other architectures are not presented as reference-validated merely because they compile.

## Validation

| Validation | Result |
| --- | --- |
| CUDA 12.8 helper compilation and `ptxas` assembly | Passed for `sm_70`, `sm_72`, `sm_75`, `sm_80`, `sm_86`, `sm_87`, `sm_89`, `sm_90`, `sm_100`, `sm_101`, and `sm_120` |
| Architecture-sensitive PTX tests | 3/3 passed on `sm_70`, `sm_90`/`sm_90a`, and `sm_120`/`sm_120a` |
| Fresh `sm_89` build | 106/106 build steps completed |
| Applicable `sm_89` CTest suite | 43/43 passed |
| RTX 4060 under WSL | `capacity_runtime_live_test` passed with two 16 KiB VMM frames; `unsupported_kernel --hbm` passed |
| CUDA-disabled build | `build_smoke` and `ptx_transform` passed, 2/2 |
| Invalid configuration checks | Multi-target and pre-Volta configurations were rejected with explicit diagnostics |
| Modified Python tools and tests | `py_compile` passed |

## Known limitations

- NVIDIA documents that GPU atomic operations on mapped host memory are not guaranteed to be atomic from the host's point of view. HBFSim uses CPU/GPU acquire-release operations and cross-domain read-modify-write operations on this mapping. Compilation and PTX assembly therefore prove instruction compatibility, not the complete live control protocol.

- Non-reference platforms remain experimental until the mapped control queue, failure transitions, coverage gate, timing mode, and capacity mode pass the live validation sequence documented in this PR.

- Four environment-dependent tests were not included in the 43/43 result: three provenance or wrapper tests are blocked by Windows drvfs file-mode and CRLF behavior, and `vmem_tuning` requires an author-local CSV file. Both public submodules remained clean.

## Documentation

See [`docs/cuda-architecture-compatibility.md`](https://github.com/zzyuanyi/HBFSim/blob/agent/decouple-cuda-architecture/docs/cuda-architecture-compatibility.md) for the feature matrix, validation policy, and NVIDIA documentation references.