### PR TITLE
Make the profile queue_depth field bound outstanding MQSim requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,6 +817,16 @@ if(HBFSIM_ENABLE_MQSIM)
     )
 
     add_executable(
+        mqsim_queue_depth_test tests/integration/mqsim_queue_depth_test.cpp
+    )
+    target_link_libraries(mqsim_queue_depth_test PRIVATE hbfsim_core)
+    add_test(NAME mqsim_queue_depth COMMAND mqsim_queue_depth_test)
+    set_tests_properties(
+        mqsim_queue_depth
+        PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+
+    add_executable(
         hbf_mqsim_bench benchmarks/mqsim/hbf_mqsim_bench.cpp
     )
     target_link_libraries(hbf_mqsim_bench PRIVATE hbfsim_core)

--- a/scripts/run_prefetch_window_sweep.py
+++ b/scripts/run_prefetch_window_sweep.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Sweep media read latency against the number of concurrently outstanding
+requests, and report how much of the media latency survives as stall.
+
+This produces the data behind the figure item 2 of
+docs/重要实现问题以及需补做实验/15-experiments-we-must-add-before-submission.md
+asks for: the residual stall fraction against media latency, one curve per
+outstanding-request count. The reasoning the figure answers is recorded in
+docs/45-预取与延迟掩盖的核实.md.
+
+WHAT THE SECOND AXIS IS, AND WHAT IT IS NOT. The sweep varies the profile
+field `queue_depth`, which bounds how many requests the device is servicing at
+once. Until the admission bound was added to
+src/mqsim_adapter/mqsim_online.cpp the field reached MQSim as
+Device_Parameter_Set::IO_Queue_Depth and was read by nothing on the HBF host
+interface, so this axis did not exist. `queue_depth` is NOT the device's
+parallel read-out unit count: item 1 of the same document sweeps that separate
+quantity, whose identity is
+
+    steady-state read bandwidth = parallel read-out units x page size / tR
+
+and a run of this script may not be reported as a measurement of it.
+
+RESIDUAL STALL FRACTION is defined here and is not taken from any paper. For
+one cell, with `requests` requests of `bytes` each:
+
+    exposed  = requests * read_latency_ns          (every access serialised)
+    floor    = requests * bytes / aggregate_bandwidth_bytes_per_s
+                                                   (bandwidth alone, latency
+                                                    fully overlapped)
+    residual = (modeled_ns - floor) / (exposed - floor)
+
+residual is 1.0 when nothing is overlapped and 0.0 when the run is limited by
+bandwidth alone. Values are clamped to [0, 1] for reporting and the raw
+modeled_ns is kept alongside so the clamp can be audited.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import tempfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# The six media latencies item 1 fixes, in nanoseconds: 1, 2, 4, 5, 10, 20 us.
+READ_LATENCY_NS = (1_000, 2_000, 4_000, 5_000, 10_000, 20_000)
+
+# 1 is what the device-side fast path models today (one global cursor,
+# src/host_service/control_layout.hpp fast_channel_tail_ns). The rest are the
+# outstanding-request counts item 1 names.
+QUEUE_DEPTHS = (1, 256, 1024, 1536, 4883)
+
+
+def build_profile(base: dict, read_latency_ns: int, queue_depth: int,
+                  directory: pathlib.Path) -> pathlib.Path:
+    profile = dict(base)
+    profile["name"] = f"{base['name']}-tr{read_latency_ns}-qd{queue_depth}"
+    profile["read_latency_ns"] = read_latency_ns
+    profile["queue_depth"] = queue_depth
+    # The measured-curve path refuses any page size other than 4096 and is not
+    # what this sweep drives; drop the metadata so the parameterised model runs.
+    profile.pop("empirical_vmem", None)
+    path = directory / f"{profile['name']}.json"
+    path.write_text(json.dumps(profile, indent=2) + "\n")
+    return path
+
+
+def run_case(binary: pathlib.Path, profile: pathlib.Path, capacity_bytes: int,
+             requests: int, bytes_per_request: int, pattern: str,
+             seed: int) -> dict:
+    command = [
+        str(binary), "--profile", str(profile),
+        "--capacity-bytes", str(capacity_bytes),
+        "--operation", "read", "--requests", str(requests),
+        "--bytes", str(bytes_per_request), "--arrival-gap-ns", "0",
+        "--pattern", pattern, "--seed", str(seed),
+    ]
+    output = subprocess.run(command, cwd=ROOT, check=True,
+                            capture_output=True, text=True, timeout=1800)
+    result = json.loads(output.stdout)
+    result["command"] = command
+    return result
+
+
+def residual_stall_fraction(result: dict, requests: int,
+                            bytes_per_request: int, read_latency_ns: int,
+                            aggregate_bandwidth: int) -> dict:
+    exposed = requests * read_latency_ns
+    floor = requests * bytes_per_request * 1e9 / aggregate_bandwidth
+    modeled = result["timing_ns"]["modeled"]
+    span = exposed - floor
+    if span <= 0:
+        # Bandwidth alone already costs more than fully serialised latency, so
+        # the cell says nothing about latency hiding. Report it, do not plot it.
+        return {"residual_stall_fraction": None, "degenerate": True,
+                "exposed_ns": exposed, "bandwidth_floor_ns": floor,
+                "modeled_ns": modeled}
+    raw = (modeled - floor) / span
+    return {"residual_stall_fraction": min(1.0, max(0.0, raw)),
+            "residual_stall_fraction_raw": raw, "degenerate": False,
+            "exposed_ns": exposed, "bandwidth_floor_ns": floor,
+            "modeled_ns": modeled}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", type=pathlib.Path,
+                        default=ROOT / "build")
+    parser.add_argument("--base-profile", type=pathlib.Path,
+                        default=ROOT / "configs/profiles/nominal.json")
+    parser.add_argument("--requests", type=int, default=4096)
+    parser.add_argument("--bytes", type=int, default=16384)
+    parser.add_argument("--capacity-bytes", type=int, default=1099511627776)
+    parser.add_argument("--pattern", default="sequential",
+                        choices=("sequential", "random"))
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", type=pathlib.Path,
+                        default=ROOT / "docs/proofs/artifacts"
+                        "/prefetch-window-sweep.json")
+    args = parser.parse_args()
+
+    binary = args.build_dir / "hbf_mqsim_bench"
+    if not binary.is_file():
+        raise RuntimeError(f"hbf_mqsim_bench is not built: {binary}")
+
+    base = json.loads(args.base_profile.read_text())
+    aggregate_bandwidth = base["aggregate_bandwidth_bytes_per_s"]
+
+    # A depth at or above the request count can never fill, so every such depth
+    # produces the same curve. Say so rather than letting the duplicate curves
+    # read as a result.
+    saturated = [depth for depth in QUEUE_DEPTHS if depth >= args.requests]
+    if saturated:
+        print(f"note: --requests {args.requests} is at or below queue depths "
+              f"{saturated}; those depths cannot fill and will produce "
+              f"identical curves. Raise --requests above "
+              f"{max(QUEUE_DEPTHS)} to separate every depth.")
+
+    report: dict = {
+        "schema_version": 1,
+        "base_profile": str(args.base_profile.relative_to(ROOT)),
+        "workload": {
+            "requests": args.requests, "bytes_per_request": args.bytes,
+            "operation": "read", "arrival_gap_ns": 0,
+            "pattern": args.pattern, "seed": args.seed,
+        },
+        "read_latency_ns": list(READ_LATENCY_NS),
+        "queue_depths": list(QUEUE_DEPTHS),
+        "cells": [],
+    }
+
+    with tempfile.TemporaryDirectory() as raw_directory:
+        directory = pathlib.Path(raw_directory)
+        for queue_depth in QUEUE_DEPTHS:
+            for read_latency_ns in READ_LATENCY_NS:
+                profile = build_profile(base, read_latency_ns, queue_depth,
+                                        directory)
+                result = run_case(binary, profile, args.capacity_bytes,
+                                  args.requests, args.bytes, args.pattern,
+                                  args.seed)
+                cell = {
+                    "queue_depth": queue_depth,
+                    "read_latency_ns": read_latency_ns,
+                    "latency_ns": result["latency_ns"],
+                    "modeled_bandwidth_bytes_per_s":
+                        result["modeled_bandwidth_bytes_per_s"],
+                }
+                cell.update(residual_stall_fraction(
+                    result, args.requests, args.bytes, read_latency_ns,
+                    aggregate_bandwidth))
+                report["cells"].append(cell)
+                fraction = cell["residual_stall_fraction"]
+                shown = "degenerate" if fraction is None else f"{fraction:.4f}"
+                print(f"qd={queue_depth:<5} tR={read_latency_ns:>6} ns  "
+                      f"residual_stall={shown}  "
+                      f"modeled={cell['modeled_ns']} ns")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mqsim_adapter/mqsim_online.cpp
+++ b/src/mqsim_adapter/mqsim_online.cpp
@@ -184,10 +184,12 @@ namespace hbfsim
         {
             HbfRequest descriptor;
             SSD_Components::User_Request *mqsim_request;
+            bool readmitted{false};
         };
 
         explicit Impl(const Profile &requested_profile)
-            : profile(requested_profile)
+            : profile(requested_profile),
+              queue_depth(std::max<std::size_t>(1, requested_profile.queue_depth))
         {
             validate_profile(profile);
             if (profile.channel_width_bits % 8 != 0)
@@ -231,6 +233,14 @@ namespace hbfsim
             while (pending_requests != 0 && Simulator->Run_next_event())
             {
             }
+            // Requests still waiting for a queue slot were never handed to
+            // MQSim, so this object still owns them.
+            for (auto *waiting : admission_queue)
+            {
+                delete waiting->mqsim_request;
+                delete waiting;
+            }
+            admission_queue.clear();
             Simulator->Reset();
             injector.reset();
             device.reset();
@@ -258,7 +268,33 @@ namespace hbfsim
             staged.clear();
         }
 
+        // The device accepts at most queue_depth requests concurrently. A
+        // request whose arrival event fires while the device is full waits in
+        // admission_queue and is re-registered when a slot frees, so the wait
+        // shows up in the request's modeled latency. Without this bound the
+        // adapter handed MQSim every request the moment its arrival event
+        // fired, which models a device with unlimited outstanding requests.
         void submit_to_device(Submission *submission)
+        {
+            if (submission->readmitted)
+            {
+                // release_admission_slots already took the slot for this
+                // request; taking a second one here would overcount.
+                submission->readmitted = false;
+                dispatch_to_device(submission);
+                return;
+            }
+            if (in_device >= queue_depth)
+            {
+                admission_queue.push_back(submission);
+                return;
+            }
+            ++in_device;
+            dispatch_to_device(submission);
+        }
+
+        // The caller has already taken the slot in in_device.
+        void dispatch_to_device(Submission *submission)
         {
             host->Submit_hbf_request(
                 submission->mqsim_request,
@@ -288,8 +324,28 @@ namespace hbfsim
                         .checksum = 0,
                         .reserved = 0,
                     });
+                    --in_device;
+                    release_admission_slots();
                 });
             delete submission;
+        }
+
+        // Called from inside a completion callback, which runs while MQSim is
+        // servicing an event. Handing the next request straight to
+        // Submit_hbf_request here would re-enter request segmentation from
+        // within request completion, so the waiting request is registered as a
+        // fresh arrival event at the current simulation time instead.
+        void release_admission_slots()
+        {
+            while (in_device < queue_depth && !admission_queue.empty())
+            {
+                auto *next = admission_queue.front();
+                admission_queue.pop_front();
+                next->readmitted = true;
+                ++in_device;
+                Simulator->Register_sim_event(Simulator->Time(),
+                                              injector.get(), next);
+            }
         }
 
         Profile profile;
@@ -303,6 +359,14 @@ namespace hbfsim
         std::deque<HbfCompletion> completions;
         std::size_t pending_requests{0};
         std::uint64_t bandwidth_cursor_ns{0};
+        // queue_depth is the profile's declared depth. in_device counts the
+        // requests holding one of those slots: handed to MQSim and not yet
+        // completed, plus any re-registered at the current time by
+        // release_admission_slots. admission_queue holds the requests that
+        // arrived while every slot was taken.
+        std::size_t queue_depth{1};
+        std::size_t in_device{0};
+        std::deque<Submission *> admission_queue;
     };
 
     void ArrivalInjector::Execute_simulator_event(MQSimEngine::Sim_Event *event)

--- a/tests/integration/mqsim_queue_depth_test.cpp
+++ b/tests/integration/mqsim_queue_depth_test.cpp
@@ -1,0 +1,125 @@
+// The profile field `queue_depth` reaches MQSim as
+// Device_Parameter_Set::IO_Queue_Depth, which upstream MQSim reads only when
+// it builds the SATA or the NVMe host interface (third_party/mqsim
+// src/exec/SSD_Device.cpp lines 355 and 360). HBFSim configures
+// HostInterface_Types::HBF, whose constructor takes no queue depth, so before
+// the admission bound in src/mqsim_adapter/mqsim_online.cpp the field was
+// parsed, validated and then read by nothing.
+//
+// This test pins the behaviour the bound is supposed to produce: with every
+// request arriving at the same instant, a shallow queue must serialise them
+// and finish later than a deep queue, and both must complete every request.
+
+#include <hbfsim/mqsim_online.hpp>
+#include <hbfsim/profile.hpp>
+#include <hbfsim/protocol.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+constexpr std::uint32_t kRequestBytes = 16'384;
+constexpr std::uint64_t kRequestCount = 32;
+
+hbfsim::HbfRequest read_request(std::uint64_t id, std::uint64_t address)
+{
+    return hbfsim::HbfRequest{
+        .request_id = id,
+        .sequence = id,
+        .arrival_ns = 0,
+        .logical_address = address,
+        .deadline_ns = 0,
+        .bytes = kRequestBytes,
+        .range_id = 1,
+        .stream_id = 0,
+        .operation =
+            static_cast<std::uint32_t>(hbfsim::RequestOperation::Read),
+        .page_generation = 1,
+        .flags = 0,
+    };
+}
+
+// Returns the latest modeled completion across every request, or 0 if any
+// request failed to complete.
+std::uint64_t drain(const hbfsim::Profile& profile, std::uint64_t& completed)
+{
+    hbfsim::MqsimOnlineEngine engine(profile);
+    for (std::uint64_t i = 0; i < kRequestCount; ++i) {
+        engine.submit(read_request(i + 1, i * kRequestBytes));
+    }
+
+    std::uint64_t last_completion = 0;
+    completed = 0;
+    while (engine.pending() != 0) {
+        const auto completion = engine.run_next_completion();
+        if (!completion.has_value() ||
+            completion->status !=
+                static_cast<std::uint32_t>(hbfsim::RequestStatus::Ready)) {
+            return 0;
+        }
+        if (completion->modeled_completion_ns > last_completion) {
+            last_completion = completion->modeled_completion_ns;
+        }
+        ++completed;
+    }
+    return last_completion;
+}
+
+}  // namespace
+
+int main()
+{
+    auto base = hbfsim::load_profile("configs/profiles/nominal.json");
+    base.capacity_bytes = 16ULL * 1024 * 1024 * 1024;
+    base.hbm_cache_bytes = 64ULL * 1024 * 1024;
+
+    auto shallow = base;
+    shallow.queue_depth = 1;
+    hbfsim::validate_profile(shallow);
+
+    auto deep = base;
+    deep.queue_depth = static_cast<std::uint32_t>(kRequestCount);
+    hbfsim::validate_profile(deep);
+
+    std::uint64_t shallow_completed = 0;
+    const auto shallow_last = drain(shallow, shallow_completed);
+    std::uint64_t deep_completed = 0;
+    const auto deep_last = drain(deep, deep_completed);
+
+    std::printf("queue_depth=1  completed=%llu last_completion_ns=%llu\n",
+                static_cast<unsigned long long>(shallow_completed),
+                static_cast<unsigned long long>(shallow_last));
+    std::printf("queue_depth=%llu completed=%llu last_completion_ns=%llu\n",
+                static_cast<unsigned long long>(kRequestCount),
+                static_cast<unsigned long long>(deep_completed),
+                static_cast<unsigned long long>(deep_last));
+
+    // Neither depth may drop or duplicate a request.
+    if (shallow_completed != kRequestCount) {
+        return __LINE__;
+    }
+    if (deep_completed != kRequestCount) {
+        return __LINE__;
+    }
+
+    // The bound has to bite: one slot cannot service a simultaneous burst as
+    // quickly as kRequestCount slots. Before the admission bound both runs
+    // produced the same completion time, because every request was handed to
+    // MQSim the moment its arrival event fired.
+    if (shallow_last <= deep_last) {
+        std::printf("queue_depth had no effect: %llu <= %llu\n",
+                    static_cast<unsigned long long>(shallow_last),
+                    static_cast<unsigned long long>(deep_last));
+        return __LINE__;
+    }
+
+    // A single slot serialises, so the burst cannot finish before one media
+    // read per request has been charged.
+    if (shallow_last < kRequestCount * base.read_latency_ns) {
+        return __LINE__;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Fixes the `queue_depth` profile field, which reached MQSim and was then read by nothing on the HBF host interface.

## The defect

`queue_depth` is parsed (`src/profile/profile.cpp:259`), validated non-zero (`:343`), and written to `Device_Parameter_Set::IO_Queue_Depth` (`src/mqsim_adapter/mqsim_online.cpp:118`). Upstream MQSim reads `IO_Queue_Depth` only when it builds the SATA or the NVMe host interface (`third_party/mqsim/src/exec/SSD_Device.cpp:355` and `:360`). HBFSim configures `HostInterface_Types::HBF`, and the `Host_Interface_HBF` constructor added by `patches/mqsim/0001-online-hbf-api.patch` takes no queue depth.

Every profile declared a depth; every run behaved as a device with unlimited outstanding requests.

## The fix

The adapter enforces the declared depth itself. A request whose arrival event fires while all slots are taken waits in an admission queue and is re-registered when a completion frees a slot, so the wait lands in that request's modeled latency.

Two details worth reviewing:

- The slot is taken *before* the waiting request is re-registered. Without that, one freed slot releases the whole queue and the requests ping-pong between the queue and the injector.
- Re-registration goes through a fresh arrival event rather than a direct `Submit_hbf_request`, because the release runs inside a completion callback and a direct call would re-enter request segmentation from within request completion.

## Evidence

`tests/integration/mqsim_queue_depth_test.cpp` fails on the previous adapter and passes on this one. 32 requests arriving together:

| | queue_depth=1 | queue_depth=32 |
|---|---|---|
| before | 10,310 ns | 10,310 ns |
| after | 329,920 ns | 10,310 ns |

## This changes recorded numbers

`hbf_mqsim_bench` on the configuration recorded in `docs/proofs/2026-08-10-capacity-runtime-non-live.md` (nominal, 4096 requests, 16384 bytes, read, `--arrival-gap-ns 0`) moves, because that run had 4096 requests in flight against a profile declaring a depth of 128:

| | before | after |
|---|---|---|
| average latency | 211,331 ns | 664,995 ns |
| p50 | 205,820 ns | 659,840 ns |
| p99 | 401,980 ns | 1,309,370 ns |
| modeled bandwidth | 166,945,778,396.94 B/s | 50,852,376,333.66 B/s |

**The proof document and any paper text citing those four numbers need re-running before submission.** What depth the profiles *should* declare is a separate question this PR does not answer.

## Also included

`scripts/run_prefetch_window_sweep.py` uses the now-live field as the outstanding-request axis of the residual-stall-fraction sweep item 2 of `docs/重要实现问题以及需补做实验/15-experiments-we-must-add-before-submission.md` asks for. The script states in its own docstring that `queue_depth` is not the device's parallel read-out unit count, which item 1 sweeps separately, so a run of it may not be reported as a measurement of that.

## Test status

CPU-only build (`-DHBFSIM_ENABLE_CUDA=OFF`). Same four tests fail before and after this change — `context_lifecycle`, `vmem_tuning`, `run_with_bpftime`, `mqsim_benchmark` — all pre-existing and unrelated; `mqsim_benchmark` fails at the same assertion on the same line in both runs. The new test takes the count from 32 to 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
